### PR TITLE
refactor: Add apikey to gradle build and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,13 @@ PresFeed has two pages:
 
 To run the app, you need to clone the repository and open it in Android Studio. Then, you can build and run the app on an emulator or a physical device.
 
-Before building the app, you need to add your own API key for the news service. To do this, create a `apikey.properties` file in the root directory of the project and add the following line, replacing `<your-api-key>` with your actual API key:
+## Adding an API key
 
+To use this app, you will need to obtain an API key and add it to the `local.properties` file in the root directory of the project. Here's how:
 
+1. Open the `local.properties` file.
+2. Add a new line to the file with the following format: `apikey="your_api_key_here"`. Replace `your_api_key_here` with your actual API key.
+3. Save the `local.properties` file.
 
 ## Technologies Used
 
@@ -29,7 +33,8 @@ PresFeed uses the following technologies:
 - [Retrofit](https://square.github.io/retrofit/) for making API calls
 - [Okhttp](https://square.github.io/okhttp/) for handling network requests
 - [Moshi](https://github.com/square/moshi) for JSON parsing
-- Unit testing with [JUnit](https://junit.org/junit4/), [Mockito](https://site.mockito.org/), and [Espresso](https://developer.android.com/training/testing/espresso)
+- [Glide](https://bumptech.github.io/glide) for image loading and image caching 
+- Unit testing with [JUnit](https://junit.org/junit4/), [Mockito](https://site.mockito.org/)
 
 ## Architecture
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,6 +7,9 @@ plugins {
     id 'androidx.navigation.safeargs'
 }
 
+def localProps = new Properties()
+localProps.load(new FileInputStream(rootProject.file("local.properties")))
+
 android {
     namespace 'dev.mehdi.bakhtiari.presfeed'
     compileSdk 33
@@ -17,7 +20,7 @@ android {
         versionCode 1
         versionName "1.0"
         buildConfigField 'String', 'BASE_URL_NEWS_API', "\"https://newsapi.org/v2/\""
-        buildConfigField 'String', 'API_KEY', "\"13222c44a0d049b991e12e057adeb5ef\""
+        buildConfigField("String", "API_KEY", "\"${localProps.getProperty("apikey")}\"")
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
@@ -85,7 +88,7 @@ dependencies {
     // AndroidX
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
-    implementation 'androidx.databinding:databinding-runtime:7.4.2'
+    implementation 'androidx.databinding:databinding-runtime:8.0.0'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.core:core-ktx:1.10.0'
     implementation 'androidx.biometric:biometric:1.2.0-alpha05'
@@ -145,16 +148,13 @@ dependencies {
 
     // JUnit 4
     testImplementation 'junit:junit:4.13.2'
-    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.5.2"
+    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.2"
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:5.7.0"
     testImplementation "androidx.arch.core:core-testing:2.2.0"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutines_version"
 
     // Mockito
     testImplementation 'org.mockito:mockito-core:3.12.4'
-
-    // MockK
-    testImplementation 'io.mockk:mockk:1.12.0'
 
     // Testing Hilt
     testAnnotationProcessor "com.google.dagger:hilt-compiler:$hilt_version"


### PR DESCRIPTION

This commit adds the `apikey` property to the `local.properties` file and updates the `build.gradle` file to read the API key from this file. Additionally, the README file has been updated with instructions for setting up the API key.

This change ensures that the API key is kept private and is not hardcoded in the source code, which improves the security of the project.
